### PR TITLE
Fix initial deploy action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,11 +5,10 @@ on:
     # Publish `main` as Docker `latest` image.
     branches:
       - main
-      - fix-deploy-action
 
     # Publish `v1.2.3` tags as releases.
-    tags:
-      - v*
+    # tags:
+    #   - v*
 
 env:
   IMAGE_NAME: bollsvenskan-api

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,6 +29,12 @@ jobs:
       # - name: Build image
       #   run: docker build api/ --file api/Dockerfile --tag $IMAGE_NAME
 
+      - name: Short sha
+        id: sha8
+        run: |
+          SHA8=$(echo $GITHUB_SHA | cut -c1-8)
+          echo ::set-output name=sha8::${SHA8}
+
       - name: Log into registry
         run: echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u jadlers --password-stdin
 
@@ -39,7 +45,7 @@ jobs:
           file: ./api/Dockerfile
           tags: |
             jadlers/${{ env.IMAGE_NAME }}:latest
-            jadlers/${{ env.IMAGE_NAME }}:sha-${{ $( echo $GITHUB_SHA | cut -c1-8) }}
+            jadlers/${{ env.IMAGE_NAME }}:sha-${{ steps.sha8.outputs.sha8 }}
 
       # - name: Push image
       #   run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,6 +46,9 @@ jobs:
           username: jadlers
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,6 +33,8 @@ jobs:
         id: sha8
         run: |
           SHA8=$(echo $GITHUB_SHA | cut -c1-8)
+
+          echo $SHA8 # Show the sha8 if inspecting action
           echo ::set-output name=sha8::${SHA8}
 
       - name: Log into registry
@@ -43,6 +45,7 @@ jobs:
         with:
           context: ./api
           file: ./api/Dockerfile
+          push: true
           tags: |
             jadlers/${{ env.IMAGE_NAME }}:latest
             jadlers/${{ env.IMAGE_NAME }}:sha-${{ steps.sha8.outputs.sha8 }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,8 +37,14 @@ jobs:
           echo $SHA8 # Show the sha8 if inspecting action
           echo ::set-output name=sha8::${SHA8}
 
-      - name: Log into registry
-        run: echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u jadlers --password-stdin
+      # - name: Log into registry
+      #   run: echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u jadlers --password-stdin
+
+      - name: Login to docker hub
+        uses: docker/login-action@v1
+        with:
+          username: jadlers
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,13 +22,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        # Should not be necessary since `main` is the default branch
-        # with:
-        #   ref: main
 
-      # - name: Build image
-      #   run: docker build api/ --file api/Dockerfile --tag $IMAGE_NAME
-
+      # Got the idea from here:
+      # https://github.com/docker/build-push-action/blob/master/UPGRADE.md#tags-with-ref-and-git-labels
       - name: Short sha
         id: sha8
         run: |
@@ -37,18 +33,18 @@ jobs:
           echo $SHA8 # Show the sha8 if inspecting action
           echo ::set-output name=sha8::${SHA8}
 
-      # - name: Log into registry
-      #   run: echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u jadlers --password-stdin
-
+      # https://github.com/docker/login-action
       - name: Login to docker hub
         uses: docker/login-action@v1
         with:
           username: jadlers
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
+      # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      # https://github.com/docker/build-push-action
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -58,22 +54,3 @@ jobs:
           tags: |
             jadlers/${{ env.IMAGE_NAME }}:latest
             jadlers/${{ env.IMAGE_NAME }}:sha-${{ steps.sha8.outputs.sha8 }}
-
-      # - name: Push image
-      #   run: |
-      #     IMAGE_ID=jadlers/$IMAGE_NAME
-
-      #     # Strip git ref prefix from version
-      #     VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-      #     # Strip "v" prefix from tag name
-      #     [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-      #     # Use Docker `latest` tag convention
-      #     [ "$VERSION" == "main" ] && VERSION=latest
-
-      #     echo IMAGE_ID=$IMAGE_ID
-      #     echo VERSION=$VERSION
-
-      #     docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-      #     docker push $IMAGE_ID:$VERSION


### PR DESCRIPTION
These changes fixes the problems with building and publishing images to docker hub with both `latest` and `sha` tags. This is done to enable easier rollback. The deployment can still be improved by supporting tags and maybe building pull requests as well.