### PR TITLE
Get heroes played for each match

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -43,6 +43,7 @@
     "webdav": "^3.6.1"
   },
   "devDependencies": {
+    "@rollup/plugin-json": "^4.1.0",
     "@types/node-fetch": "^2.5.7",
     "concurrently": "^5.2.0",
     "jest": "^26.1.0",
@@ -52,9 +53,7 @@
   },
   "jest": {
     "preset": "ts-jest",
-    "setupFiles": [
-      "dotenv/config"
-    ]
+    "setupFiles": ["dotenv/config"]
   },
   "prettier": {
     "singleQuote": false

--- a/api/rollup.config.js
+++ b/api/rollup.config.js
@@ -1,5 +1,6 @@
 // import typescript from "@rollup/plugin-typescript";
 import typescript from "rollup-plugin-typescript2";
+import jsonModule from "@rollup/plugin-json";
 
 export default {
   input: "src/server.js",
@@ -7,7 +8,7 @@ export default {
     dir: "build",
     format: "es",
   },
-  plugins: [typescript()],
+  plugins: [typescript(), jsonModule()],
   external: [
     "@hapi/joi",
     "body-parser",

--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -171,8 +171,21 @@ export async function getAllMatches() {
   return await db.any("SELECT * FROM matches WHERE league_id = 2");
 }
 
-export async function getMatch(matchId) {
-  return await db.one("SELECT * FROM matches WHERE id = $1", [matchId]);
+export async function getMatch(matchId: number) {
+  const row = await db.one("SELECT * FROM matches WHERE id = $1", matchId);
+  return {
+    id: row.id as number,
+    date: row.date as number,
+    score: row.score as string,
+    winningTeamId: row.winning_team_id as number,
+    leagueId: row.winning_team_id as number,
+    dotaMatchId: parseInt(row.dota_match_id),
+    season: row.season as number,
+    claimedFirstBlood: row.claimed_first_blood as number,
+    diedFirstBlood: row.died_first_blood as number,
+    firstBloodMock: row.first_blood_mock as number,
+    firstBloodPraise: row.first_blood_praise as number,
+  };
 }
 
 export async function addNewMatch(

--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -286,6 +286,17 @@ export async function addStatsForUserToMatch(
   );
 }
 
+export async function setPlayedHeroesInMatch(
+  matchId: number,
+  userId: number,
+  heroId: number
+) {
+  await db.oneOrNone(
+    "UPDATE user_match_stats SET dota_hero_id = $3 WHERE match_id = $1 AND user_id = $2",
+    [matchId, userId, heroId]
+  );
+}
+
 export async function setUserEloRatingForMatch(matchId, userId, eloRating) {
   return db.any(
     "UPDATE user_match_stats SET elo_rating = $3 WHERE match_id = $1 AND user_id = $2",
@@ -293,7 +304,7 @@ export async function setUserEloRatingForMatch(matchId, userId, eloRating) {
   );
 }
 
-export function getMatchByDotaMatchId(dotaMatchId) {
+export function getMatchByDotaMatchId(dotaMatchId: number) {
   return db.oneOrNone("SELECT * FROM matches WHERE dota_match_id = '$1'", [
     dotaMatchId,
   ]);

--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -304,10 +304,24 @@ export async function setUserEloRatingForMatch(matchId, userId, eloRating) {
   );
 }
 
-export function getMatchByDotaMatchId(dotaMatchId: number) {
+export async function getMatchByDotaMatchId(dotaMatchId: number) {
   return db.oneOrNone("SELECT * FROM matches WHERE dota_match_id = '$1'", [
     dotaMatchId,
   ]);
+}
+
+export async function getMatchesMissingOpenDotaInfo() {
+  const rows: { id: number }[] = await db.manyOrNone(`
+    SELECT DISTINCT m.id
+    FROM matches m
+    JOIN user_match_stats ums
+      ON m.id = ums.match_id
+    WHERE league_id = 2 AND (
+      m.date IS NULL OR
+      ums.dota_hero_id IS NULL
+    )
+    ORDER BY m.id`);
+  return rows.map((r) => r.id);
 }
 
 export async function setPlayedDateTime(matchId, datetime) {

--- a/api/src/external/opendota.test.ts
+++ b/api/src/external/opendota.test.ts
@@ -1,5 +1,8 @@
-import { getMatch, timePlayed, dateTimeFormat } from "./opendota";
+import { getMatch, timePlayed, heroesPlayed } from "./opendota";
 import mockMatch from "../../lastmatch-opendota.json";
+
+import { endDbConnection } from "../db";
+afterAll(() => endDbConnection());
 
 describe("getMatch", () => {
   it("fetches mock correctly", async () => {
@@ -37,5 +40,17 @@ describe("Getting match play time", () => {
     const matchId = 5751025193;
     const res = await timePlayed(matchId);
     expect(res).toEqual("0020-12-20 20:57:18");
+  });
+});
+
+describe("Heroes played", () => {
+  it("Finds the account_id and hero_id", async () => {
+    const playedHeroes = await heroesPlayed(null, mockMatch);
+    // {userId: 23, heroId: 52}
+    expect(playedHeroes).toContainEqual({
+      steamId: 41691912,
+      userId: 23,
+      heroId: 52,
+    });
   });
 });

--- a/api/src/external/opendota.test.ts
+++ b/api/src/external/opendota.test.ts
@@ -43,14 +43,24 @@ describe("Getting match play time", () => {
   });
 });
 
-describe("Heroes played", () => {
-  it("Finds the account_id and hero_id", async () => {
+describe("heroesPlayed", () => {
+  it("finds the account_id and hero_id for existing hero", async () => {
     const playedHeroes = await heroesPlayed(null, mockMatch);
     // {userId: 23, heroId: 52}
     expect(playedHeroes).toContainEqual({
       steamId: 41691912,
       userId: 23,
       heroId: 52,
+    });
+  });
+
+  it("gives standin userId for non-found users", async () => {
+    const playedHeroes = await heroesPlayed(null, mockMatch);
+
+    expect(playedHeroes).toContainEqual({
+      steamId: 92698518,
+      userId: 25,
+      heroId: 43,
     });
   });
 });

--- a/api/src/external/opendota.ts
+++ b/api/src/external/opendota.ts
@@ -9,12 +9,12 @@ export interface OpenDotaMatch {
   [x: string]: any;
 }
 
-export async function getMatch(matchId: number): Promise<OpenDotaMatch> {
-  const url = new URL(`api/matches/${matchId}`, "https://api.opendota.com");
+export async function getMatch(dotaMatchId: number): Promise<OpenDotaMatch> {
+  const url = new URL(`api/matches/${dotaMatchId}`, "https://api.opendota.com");
   url.searchParams.append("api_key", OPENDOTA_API_KEY);
   const res = await fetch(url.href);
   if (res.ok) {
-    const parsed = await res.json();
+    const parsed: OpenDotaMatch = await res.json();
     return parsed;
   }
   return Promise.reject(await res.json());

--- a/api/src/external/opendota.ts
+++ b/api/src/external/opendota.ts
@@ -26,14 +26,7 @@ export async function timePlayed(
   matchId: number,
   odData: OpenDotaMatch = null
 ): Promise<String> {
-  if (!odData) {
-    try {
-      odData = await getMatch(matchId);
-    } catch (err) {
-      console.error("Could not fetch match from opendota", err);
-      return Promise.reject();
-    }
-  }
+  odData = await fetchMatchIfMissing(matchId, odData);
 
   // Extract the date
   const unixtime = odData.start_time * 1000;
@@ -46,4 +39,18 @@ export function dateTimeFormat(d: Date): String {
   const time = `${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}`;
 
   return `${date} ${time}`;
+}
+async function fetchMatchIfMissing(
+  matchId: number,
+  obj: OpenDotaMatch | null
+): Promise<OpenDotaMatch> {
+  if (!obj) {
+    try {
+      obj = await getMatch(matchId);
+    } catch (err) {
+      console.error("Could not fetch match from opendota", err);
+      return Promise.reject();
+    }
+  }
+  return obj;
 }

--- a/api/src/external/opendota.ts
+++ b/api/src/external/opendota.ts
@@ -3,7 +3,7 @@ import fetch from "node-fetch";
 import { OPENDOTA_API_KEY } from "../config";
 import { getPlayerBySteamId } from "../player";
 
-interface OpenDotaMatch {
+export interface OpenDotaMatch {
   start_time: number;
   players: { account_id: number; hero_id: number }[];
   [x: string]: any;

--- a/api/src/external/opendota.ts
+++ b/api/src/external/opendota.ts
@@ -62,6 +62,10 @@ export async function heroesPlayed(
           heroId: p.hero_id,
         };
       } catch (err) {
+        // NOTE: For Pontus second account
+        if (p.account_id === 115345354) {
+          return { userId: 20, steamId: p.account_id, heroId: p.hero_id };
+        }
         return { userId: 25, steamId: p.account_id, heroId: p.hero_id };
       }
     })

--- a/api/src/match.ts
+++ b/api/src/match.ts
@@ -1,7 +1,36 @@
-import { getMatch, setPlayedDateTime } from "./db";
-import { timePlayed } from "./external/opendota";
+import { getMatch, setPlayedDateTime, setPlayedHeroesInMatch } from "./db";
+import {
+  timePlayed,
+  heroesPlayed,
+  OpenDotaMatch,
+  getMatch as getOpenDotaMatch,
+} from "./external/opendota";
 
-export async function setPlayTime(matchId: number): Promise<String> {
+export async function fetchAllOpenDotaInfo(
+  matchId: number,
+  openDotaData: OpenDotaMatch = null
+): Promise<[String, { userId: number; heroId: number }[]]> {
+  if (!openDotaData) {
+    try {
+      const { dotaMatchId } = await getMatch(matchId);
+      openDotaData = await getOpenDotaMatch(dotaMatchId);
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  const storedOpenDotaData = await Promise.all([
+    setPlayTime(matchId, openDotaData),
+    storeHeroesPlayed(matchId, openDotaData),
+  ]);
+
+  return storedOpenDotaData;
+}
+
+async function setPlayTime(
+  matchId: number,
+  openDotaData: OpenDotaMatch = null
+): Promise<String> {
   try {
     const { dotaMatchId } = await getMatch(matchId);
     const datetime = await timePlayed(dotaMatchId, openDotaData);
@@ -11,4 +40,17 @@ export async function setPlayTime(matchId: number): Promise<String> {
     console.error(err);
     return null;
   }
+}
+
+async function storeHeroesPlayed(
+  matchId: number,
+  openDotaData: OpenDotaMatch = null
+): Promise<{ userId: number; heroId: number }[]> {
+  const { dotaMatchId } = await getMatch(matchId);
+  const heroes = await heroesPlayed(dotaMatchId, openDotaData);
+  await Promise.all(
+    heroes.map((h) => setPlayedHeroesInMatch(matchId, h.userId, h.heroId))
+  );
+  heroes.forEach((h) => delete h.steamId);
+  return heroes;
 }

--- a/api/src/match.ts
+++ b/api/src/match.ts
@@ -3,8 +3,8 @@ import { timePlayed } from "./external/opendota";
 
 export async function setPlayTime(matchId: number): Promise<String> {
   try {
-    const match = await getMatch(matchId);
-    const datetime = await timePlayed(match.dota_match_id);
+    const { dotaMatchId } = await getMatch(matchId);
+    const datetime = await timePlayed(dotaMatchId, openDotaData);
     await setPlayedDateTime(matchId, datetime);
     return datetime;
   } catch (err) {

--- a/api/src/match.ts
+++ b/api/src/match.ts
@@ -1,11 +1,11 @@
-import * as db from "./db.js";
+import { getMatch, setPlayedDateTime } from "./db";
 import { timePlayed } from "./external/opendota";
 
 export async function setPlayTime(matchId: number): Promise<String> {
   try {
-    const match = await db.getMatch(matchId);
+    const match = await getMatch(matchId);
     const datetime = await timePlayed(match.dota_match_id);
-    await db.setPlayedDateTime(matchId, datetime);
+    await setPlayedDateTime(matchId, datetime);
     return datetime;
   } catch (err) {
     console.error(err);

--- a/api/src/player.test.ts
+++ b/api/src/player.test.ts
@@ -1,0 +1,25 @@
+import { getPlayerBySteamId } from "./player";
+// import mockMatch from "../../lastmatch-opendota.json";
+
+import { endDbConnection } from "./db";
+afterAll(() => endDbConnection());
+
+describe("Get player with steam32id", () => {
+  it("fetches correct existing player", async () => {
+    const jacobSteam32id = 75463477;
+    const res = await getPlayerBySteamId(jacobSteam32id);
+
+    expect(res.id).toEqual(1);
+    expect(res.username).toEqual("Jacob");
+  });
+
+  it("fetches non-existing player as standin", async (done) => {
+    const missingId = 123;
+    try {
+      await getPlayerBySteamId(missingId);
+    } catch (err) {
+      expect(err).toMatch(`No user`);
+    }
+    done();
+  });
+});

--- a/api/src/player.ts
+++ b/api/src/player.ts
@@ -306,7 +306,7 @@ function getPlayerFirstBloodStats(
       const firstBloodData = await Promise.all(
         matches.map(async (match) => {
           const matchData = await getMatch(match.matchId);
-          return [matchData.died_first_blood, matchData.claimed_first_blood];
+          return [matchData.diedFirstBlood, matchData.claimedFirstBlood];
         })
       );
       const res: [number, number] = [0, 0];
@@ -362,7 +362,7 @@ function getEloPerSeason(
       const matchesWithDotaId = await Promise.all(
         matches.map(async (m) => {
           const matchInfo = await getMatch(m.matchId);
-          const dotaMatchId: number = parseInt(matchInfo.dota_match_id);
+          const dotaMatchId: number = matchInfo.dotaMatchId;
           return { ...m, dotaMatchId };
         })
       );

--- a/api/src/player.ts
+++ b/api/src/player.ts
@@ -1,6 +1,7 @@
 import {
   getUser,
   getUserMatches,
+  getUserBySteamId,
   getUserStatsFromMatch,
   getUserLeagueSeasons,
   getMatch,
@@ -104,6 +105,14 @@ export function getDotaPlayer(playerId: number): Promise<DotaPlayer> {
       reject(err);
     }
   });
+}
+
+/**
+ * Returns the player with given steamId if exists, otherwise rejects
+ */
+export async function getPlayerBySteamId(steamId: number): Promise<Player> {
+  const player = await getUserBySteamId(steamId);
+  return player;
 }
 
 /*******************************

--- a/api/src/player.ts
+++ b/api/src/player.ts
@@ -4,7 +4,7 @@ import {
   getUserStatsFromMatch,
   getUserLeagueSeasons,
   getMatch,
-} from "./db.js";
+} from "./db";
 import { removeNullEntries } from "./util";
 
 export type Player = {

--- a/api/src/quickfix.js
+++ b/api/src/quickfix.js
@@ -2,7 +2,7 @@
  * The goal is for this file to be empty at all times.
  */
 
-import * as db from "./db.js";
+import * as db from "./db";
 import { ratingDiff } from "./elo.ts";
 
 /**

--- a/api/src/routes/leagueRoutes.js
+++ b/api/src/routes/leagueRoutes.js
@@ -1,7 +1,7 @@
 import express from "express";
 import Joi from "@hapi/joi";
 
-import * as db from "../db";
+import * as db from "../db.ts";
 
 const router = express.Router();
 

--- a/api/src/routes/leagueRoutes.js
+++ b/api/src/routes/leagueRoutes.js
@@ -1,7 +1,7 @@
 import express from "express";
 import Joi from "@hapi/joi";
 
-import * as db from "../db.js";
+import * as db from "../db";
 
 const router = express.Router();
 

--- a/api/src/routes/matchRoutes.js
+++ b/api/src/routes/matchRoutes.js
@@ -258,26 +258,25 @@ router.post("/", async (req, res, next) => {
 
 router.get("/od-fetch/all", async (req, res, next) => {
   try {
-    let matches = await db.getAllMatchesFromLeague(2);
+    let matchIds = await db.getMatchesMissingOpenDotaInfo();
 
-    matches = matches.filter((m) => m.date === null);
-    const initialNullDates = matches.length;
-    matches.splice(50); // Keep first 50 elements
+    const initialNumMatches = matchIds.length;
+    matchIds.splice(50); // Keep first 50 elements
 
-    if (matches.length === 0) {
+    if (matchIds.length === 0) {
       return res.status(200).json({ msg: "No match is missing information." });
     }
 
     console.log(
       "Updating matches (maximum 50, 60 api calls/min limit):",
-      matches.map((m) => m.id)
+      matchIds
     );
-    await Promise.all(matches.map((m) => fetchAllOpenDotaInfo(m.id)));
+    await Promise.all(matchIds.map((matchId) => fetchAllOpenDotaInfo(matchId)));
 
     res.status(200).json({
       msg: `Successfully updated open-dota data for ${
-        matches.length
-      } matches. ${Math.max(0, initialNullDates - 50)} remain without date.`,
+        matchIds.length
+      } matches. ${Math.max(0, initialNumMatches - 50)} remain without date.`,
     });
   } catch (err) {
     console.error(err);

--- a/api/src/routes/matchRoutes.js
+++ b/api/src/routes/matchRoutes.js
@@ -1,7 +1,7 @@
 import express from "express";
 import Joi from "@hapi/joi";
 
-import * as db from "../db";
+import * as db from "../db.ts";
 import { ratingDiff } from "../elo.ts";
 import { recalculateEloRatingForAllPlayers } from "../quickfix.js";
 import { setPlayTime } from "../match.ts";

--- a/api/src/routes/matchRoutes.js
+++ b/api/src/routes/matchRoutes.js
@@ -1,7 +1,7 @@
 import express from "express";
 import Joi from "@hapi/joi";
 
-import * as db from "../db.js";
+import * as db from "../db";
 import { ratingDiff } from "../elo.ts";
 import { recalculateEloRatingForAllPlayers } from "../quickfix.js";
 import { setPlayTime } from "../match.ts";

--- a/api/src/routes/playerRoutes.js
+++ b/api/src/routes/playerRoutes.js
@@ -1,7 +1,7 @@
 import express from "express";
 import Joi from "@hapi/joi";
 
-import * as db from "../db";
+import * as db from "../db.ts";
 import { getPlayer, getDotaPlayer } from "../player.ts";
 
 const router = express.Router();

--- a/api/src/routes/playerRoutes.js
+++ b/api/src/routes/playerRoutes.js
@@ -1,7 +1,7 @@
 import express from "express";
 import Joi from "@hapi/joi";
 
-import * as db from "../db.js";
+import * as db from "../db";
 import { getPlayer, getDotaPlayer } from "../player.ts";
 
 const router = express.Router();

--- a/api/src/routes/variousDotaRoutes.ts
+++ b/api/src/routes/variousDotaRoutes.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import Joi from "@hapi/joi";
 
-import { addNewFirstBloodPhrase, getAllFirstBloodPhrases } from "../db.js";
+import { addNewFirstBloodPhrase, getAllFirstBloodPhrases } from "../db";
 import { recalculateEloRatingForAllPlayers } from "../quickfix.js";
 
 const router = Router();

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -9,7 +9,6 @@ import logger from "./middleware/logging";
 import monitoring, { monitoringEndpoint } from "./middleware/monitoring";
 
 // Import my other modules
-import * as db from "./db.js";
 import { SERVER_PORT, NEXTCLOUD } from "./config.ts";
 import connectSocketIo from "./socketio.js";
 import { getPlayer, getDotaPlayer } from "./player.ts";

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "target": "ES6"
+    "target": "ES6",
     "resolveJsonModule": true
   }
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -3,5 +3,6 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "target": "ES6"
+    "resolveJsonModule": true
   }
 }

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -504,7 +504,14 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@rollup/pluginutils@^3.1.0":
+"@rollup/plugin-json@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
+  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+
+"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==

--- a/database-migrations/2021-01-04.sql
+++ b/database-migrations/2021-01-04.sql
@@ -1,0 +1,3 @@
+-- Generated with Adminer
+ALTER TABLE "user_match_stats"
+ADD "dota_hero_id" smallint NULL;

--- a/schema.sql
+++ b/schema.sql
@@ -78,6 +78,7 @@ CREATE TABLE user_match_stats (
        sentries_placed INT,
        sentries_destroyed INT,
        fantasy_points DOUBLE PRECISION,
+       dota_hero_id SMALLINT,
        PRIMARY KEY (user_id, match_id),
        FOREIGN KEY (user_id) REFERENCES users (id)
                ON DELETE SET NULL ON UPDATE CASCADE,


### PR DESCRIPTION
This PR closes #10. It extracts the hero each player played as in the games when a game is added. The endpoints to fetch data from [opendota](https://opendota.com) now also checks for heroes making it possible to parse all previous games easily.