### PR TITLE
Add authorization and endpoint to update player

### DIFF
--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -13,8 +13,7 @@ export async function isAuthorized(req, res, next) {
   // TODO: Check if the given key is valid
   try {
     const user = await db.getUserByApiKey(apiKey);
-    req.authorizedUser = user.username;
-    console.log(user);
+    req.authorizedUser = user;
   } catch (_) {
     const error = `The API key '${apiKey}' is not valid.`;
     res.status(401);

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -1,16 +1,20 @@
+import { Request, Response, NextFunction } from "express";
 import * as db from "./db";
 
 /**
  * Checks that a valid API key is sent with the request.
  */
-export async function isAuthorized(req, res, next) {
-  const apiKey = req.query.api_key;
+export async function isAuthorized(
+  req: Request & { authorizedUser: any },
+  res: Response,
+  next: NextFunction
+) {
+  const apiKey = req.query.api_key as string;
   if (!apiKey) {
     res.status(401);
     return next("No API key provided");
   }
 
-  // TODO: Check if the given key is valid
   try {
     const user = await db.getUserByApiKey(apiKey);
     req.authorizedUser = user;

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -1,0 +1,26 @@
+import * as db from "./db";
+
+/**
+ * Checks that a valid API key is sent with the request.
+ */
+export async function isAuthorized(req, res, next) {
+  const apiKey = req.query.api_key;
+  if (!apiKey) {
+    res.status(401);
+    return next("No API key provided");
+  }
+
+  // TODO: Check if the given key is valid
+  try {
+    const user = await db.getUserByApiKey(apiKey);
+    req.authorizedUser = user.username;
+    console.log(user);
+  } catch (_) {
+    const error = `The API key '${apiKey}' is not valid.`;
+    res.status(401);
+    next(error);
+  }
+
+  // If no errors, proceed!
+  next();
+}

--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -63,6 +63,11 @@ export async function getUserBySteamId(steamId: number): Promise<UserEntity> {
   return userRowToObj(row);
 }
 
+export async function getUserByApiKey(apiKey: string): Promise<UserEntity> {
+  const row = await db.one("SELECT * FROM users WHERE api_key = $1", apiKey);
+  return userRowToObj(row);
+}
+
 export function setUserEloRating(userId, newRating) {
   return db.any("UPDATE users SET elo_rating = $2 WHERE id = $1", [
     userId,

--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -41,8 +41,10 @@ function userRowToObj(row: any): UserEntity {
   };
 }
 
-export function getAllUsers() {
-  return db.any("SELECT * FROM users");
+export async function getAllUsers(): Promise<UserEntity[]> {
+  const rows = await db.many("SELECT * FROM users");
+  const users = rows.map((r) => userRowToObj(r));
+  return users;
 }
 
 export async function getUser(userId: number): Promise<UserEntity> {

--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -84,6 +84,28 @@ export function getNumberOfMatchesInLeague(userId, leagueId) {
   );
 }
 
+export async function updatePlayer(player: Player) {
+  await db.none(
+    `UPDATE users SET
+       username = $2,
+       full_name = $3,
+       elo_rating = $4,
+       steam32id = $5,
+       discord_id = $6,
+       discord_username = $7
+     WHERE id = $1`,
+    [
+      player.id,
+      player.username,
+      player.fullName,
+      player.eloRating,
+      player.steam32id,
+      player.discordId,
+      player.discordUsername,
+    ]
+  );
+}
+
 /**
  * Returns a list of matches the user has played in.
  */

--- a/api/src/db/entities.ts
+++ b/api/src/db/entities.ts
@@ -1,0 +1,11 @@
+export interface UserEntity {
+  id: number;
+  username: string;
+  password?: string;
+  apiKey?: string;
+  fullName?: string;
+  eloRating?: number;
+  steam32id?: string;
+  discordId?: string;
+  discordUsername?: string;
+}

--- a/api/src/middleware/logging.js
+++ b/api/src/middleware/logging.js
@@ -4,8 +4,15 @@ morgan.token("post-body", (req, _) =>
   req.method === "POST" ? JSON.stringify(req.body) : ""
 );
 
-const logger = morgan("[:date[iso]] :status :method :url :post-body", {
-  skip: (req, _) => req.path === "/metrics",
-});
+morgan.token("authorized-user", (req, _) =>
+  req.authorizedUser ? `authUser(${req.authorizedUser})` : "noAuth"
+);
+
+const logger = morgan(
+  "[:date[iso]] :status :method :url :authorized-user :post-body",
+  {
+    skip: (req, _) => req.path === "/metrics",
+  }
+);
 
 export default logger;

--- a/api/src/middleware/logging.js
+++ b/api/src/middleware/logging.js
@@ -1,7 +1,7 @@
 import morgan from "morgan";
 
 morgan.token("post-body", (req, _) =>
-  req.method === "POST" ? JSON.stringify(req.body) : ""
+  ["POST", "PUT"].includes(req.method) ? JSON.stringify(req.body) : ""
 );
 
 morgan.token("authorized-user", (req, _) =>

--- a/api/src/middleware/logging.js
+++ b/api/src/middleware/logging.js
@@ -5,7 +5,7 @@ morgan.token("post-body", (req, _) =>
 );
 
 morgan.token("authorized-user", (req, _) =>
-  req.authorizedUser ? `authUser(${req.authorizedUser})` : "noAuth"
+  req.authorizedUser ? `authUser(${req.authorizedUser.username})` : "noAuth"
 );
 
 const logger = morgan(

--- a/api/src/player.test.ts
+++ b/api/src/player.test.ts
@@ -17,7 +17,7 @@ describe("Get player with steam32id", () => {
     try {
       await getPlayerBySteamId(missingId);
     } catch (err) {
-      expect(err).toMatch(`No user`);
+      expect(err.message).toMatch(`No user`);
     }
     done();
   });

--- a/api/src/player.ts
+++ b/api/src/player.ts
@@ -97,6 +97,16 @@ export async function getPlayerBySteamId(steamId: number): Promise<Player> {
   return player;
 }
 
+/**
+ * Removes sensitive data of a user which should not be included in any response.
+ */
+export function stripSecrets(user: UserEntity) {
+  const secretProperties = ["password", "apiKey"];
+  for (const prop of secretProperties) {
+    delete user[prop];
+  }
+  return user;
+}
 /*******************************
  * Unexported helper functions *
  *******************************/

--- a/api/src/player.ts
+++ b/api/src/player.ts
@@ -6,6 +6,7 @@ import {
   getUserLeagueSeasons,
   getMatch,
 } from "./db";
+import { UserEntity } from "./db/entities";
 import { removeNullEntries } from "./util";
 
 export type Player = {
@@ -54,26 +55,7 @@ const DOTA_LEAGUE_IDS = [2];
 export function getPlayer(playerId: number): Promise<Player> {
   return new Promise(async (resolve, reject) => {
     try {
-      const {
-        id,
-        username,
-        full_name: fullName,
-        elo_rating: eloRating,
-        steam32id,
-        discord_id: discordId,
-        discord_username: discordUsername,
-      } = await getUser(playerId);
-
-      let player: Player = {
-        id: id as number,
-        username: username as string,
-        fullName: fullName as string,
-        eloRating: eloRating as number,
-        steam32id: steam32id as string,
-        discordId: discordId as string,
-        discordUsername: discordUsername as string,
-      };
-
+      let player: Player = await getUser(playerId);
       player = removeNullEntries(player) as Player;
       resolve(player);
     } catch (err) {

--- a/api/src/player.ts
+++ b/api/src/player.ts
@@ -4,6 +4,7 @@ import {
   getUserBySteamId,
   getUserStatsFromMatch,
   getUserLeagueSeasons,
+  updatePlayer as dbUpdatePlayer,
   getMatch,
 } from "./db";
 import { UserEntity } from "./db/entities";
@@ -95,6 +96,23 @@ export function getDotaPlayer(playerId: number): Promise<DotaPlayer> {
 export async function getPlayerBySteamId(steamId: number): Promise<Player> {
   const player = await getUserBySteamId(steamId);
   return player;
+}
+
+/**
+ * Merges the currently stored player with the provided one
+ * and stores in DB.
+ */
+export async function updatePlayer(player: Player): Promise<Player> {
+  const currentUser = await getPlayer(player.id);
+  const newUser = { ...currentUser, ...player };
+
+  try {
+    await dbUpdatePlayer(newUser);
+    return newUser;
+  } catch (err) {
+    console.log(err);
+    return Promise.reject("Error updating player in database");
+  }
 }
 
 /**

--- a/api/src/routes/playerRoutes.js
+++ b/api/src/routes/playerRoutes.js
@@ -1,8 +1,14 @@
 import express from "express";
 import Joi from "@hapi/joi";
 
+import { isAuthorized } from "../auth.ts";
 import * as db from "../db.ts";
-import { getPlayer, getDotaPlayer, stripSecrets } from "../player.ts";
+import {
+  getPlayer,
+  getDotaPlayer,
+  updatePlayer,
+  stripSecrets,
+} from "../player.ts";
 
 const router = express.Router();
 
@@ -96,6 +102,43 @@ router.post("/", async (req, res, next) => {
       res.status(500).json({ message: "Internal server error" });
       next();
     }
+  }
+});
+
+// Update single player
+router.put("/:playerId", isAuthorized, async (req, res, next) => {
+  const playerId = parseInt(req.params.playerId);
+  if (!playerId) {
+    res.status(400);
+    return next(`Invalid player id '${req.params.playerId}'.`);
+  }
+
+  // null allowed for nullable columns in DB
+  const schema = Joi.object().keys({
+    username: Joi.string(),
+    eloRating: Joi.number().allow(null),
+    discordId: Joi.string().allow(null),
+    discordUsername: Joi.string().allow(null),
+    steam32id: Joi.string().allow(null),
+  });
+
+  const { value: validData, error } = schema.validate(req.body, {
+    abortEarly: false,
+  });
+  if (error) {
+    res.status(400);
+    return next(error.message);
+  }
+
+  try {
+    const updatedPlayer = await updatePlayer({ id: playerId, ...validData });
+    res.status(200).json({
+      message: `Updated player with id=${playerId}`,
+      player: stripSecrets(updatedPlayer),
+    });
+    next();
+  } catch (err) {
+    next(err);
   }
 });
 

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -12,6 +12,7 @@ import monitoring, { monitoringEndpoint } from "./middleware/monitoring";
 import { SERVER_PORT, NEXTCLOUD } from "./config.ts";
 import connectSocketIo from "./socketio.js";
 import { getPlayer, getDotaPlayer } from "./player.ts";
+import { isAuthorized } from "./auth.ts";
 
 // Routes
 import matchRoutes from "./routes/matchRoutes.js";
@@ -89,6 +90,13 @@ app.use((req, res, next) => {
   }
 
   next();
+});
+
+app.use((err, _req, res, _next) => {
+  if (res.statusCode === 200) {
+    res.status(500); // Add generic error
+  }
+  res.json({ error: err });
 });
 
 server.listen(SERVER_PORT, () =>

--- a/database-migrations/2021-01-10.sql
+++ b/database-migrations/2021-01-10.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "users"
+ADD "api_key" character varying(40) NULL;
+
+ALTER TABLE "users"
+ADD CONSTRAINT "users_api_key" UNIQUE ("api_key");

--- a/schema.sql
+++ b/schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE users (
   full_name        VARCHAR(80),
   username         VARCHAR(50)    NOT NULL        UNIQUE,
   password         VARCHAR(140),
+  api_key          VARCHAR(40)    UNIQUE,
   elo_rating       INT            DEFAULT 1500, -- Current rating
   steam32id        VARCHAR(12)    UNIQUE,
   discord_id       VARCHAR(22)    UNIQUE,


### PR DESCRIPTION
This PR closes #11. It adds an endpoint `PUT /player/:playerId` which accepts an object with the following structure:

```js
{
    username: Joi.string(),
    eloRating: Joi.number().allow(null),
    discordId: Joi.string().allow(null),
    discordUsername: Joi.string().allow(null),
    steam32id: Joi.string().allow(null),
}
```

Any number of the properties may be supplied and the values will be merged with the current values stored for the user with id = `playerId`.

In order to secure this API keys and middleware to authorize a request has also been implemented. Currently only the new endpoint require authentication but all endpoints which update the data stored should require authentication.