### PR TITLE
Add soft deletes

### DIFF
--- a/database-migrations/2021-01-19.sql
+++ b/database-migrations/2021-01-19.sql
@@ -1,0 +1,24 @@
+-- Generated with adminer
+ALTER TABLE "matches"
+ADD "is_deleted" boolean NOT NULL DEFAULT false;
+
+-- Set is_deleted to false for ALL existing matches
+UPDATE matches
+SET is_deleted = false;
+
+-- Soft delete all known faulty matches
+UPDATE matches
+SET is_deleted = true
+WHERE dota_match_id IN (
+    '5310965954',
+    '5314558866',
+    '5314651376',
+    '5321557425',
+    '5322026529',
+    '5394885055',
+    '5471079116',
+    '5693051343',
+    '5693053375',
+    '5693144498',
+    '5763502972'
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,10 @@ version: '3.5'
 
 services:
   api_server:
+    image: jadlers/bollsvenskan-api:latest
+    restart: unless-stopped
     depends_on:
       - db
-    image: jadlers/bollsvenskan-api:latest
     ports:
       - "5000:${API_SERVER_PORT}"
     env_file: .env
@@ -13,7 +14,7 @@ services:
 
   db:
     image: postgres:11-alpine
-    restart: always
+    restart: unless-stopped
     volumes:
       - ./database/data:/var/lib/postgresql/data
       - ./database/init:/docker-entrypoint-initdb.d
@@ -24,10 +25,10 @@ services:
       - TZ=Europe/Stockholm
 
   adminer:
+    image: adminer:latest
+    restart: unless-stopped
     depends_on:
       - db
-    image: adminer:latest
-    restart: on-failure
     ports:
       - "8080:8080"
     environment:

--- a/schema.sql
+++ b/schema.sql
@@ -39,6 +39,7 @@ CREATE TABLE first_blood_phrases (
 -- DROP TABLE IF EXISTS matches;
 CREATE TABLE matches (
   ID                  SERIAL       PRIMARY KEY,
+  is_deleted          BOOLEAN      NOT NULL DEFAULT false,
   DATE                TIMESTAMP,
   score               VARCHAR(40),
   winning_team_id     INT          NOT NULL,


### PR DESCRIPTION
This PR closes #12. A new column in the database table `matches` is created. All queries which use the `matches` table ignore the rows where `is_deleted` is set.