### PR TITLE
Add endpoint for getting deleted matches

### DIFF
--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -3,7 +3,7 @@
 import pgp from "pg-promise";
 
 import { Player } from "./player";
-import { UserEntity } from "./db/entities";
+import { MatchEntity, UserEntity } from "./db/entities";
 
 import { DATABASE_CONNECTION_URL } from "./config";
 const db = pgp(/* initialization options */)(DATABASE_CONNECTION_URL);
@@ -214,6 +214,23 @@ export async function addTeamToMatch(matchId, teamId) {
 }
 
 /* MATCHES */
+
+function matchRowToObj(row: any): MatchEntity {
+  return {
+    id: row.id,
+    isDeleted: row.is_deleted,
+    date: row.date,
+    score: row.score,
+    winningTeamId: row.winning_team_id,
+    leagueId: row.league_id,
+    season: row.season,
+    dotaMatchId: row.dota_match_id,
+    diedFirstBlood: row.died_first_blood,
+    claimedFirstBlood: row.claimed_first_blood,
+    firstBloodMock: row.first_blood_mock,
+    firstBloodPraise: row.first_blood_praise,
+  };
+}
 
 export async function getAllMatches() {
   return await db.any(

--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -457,6 +457,14 @@ export async function getLastDotaMatchIdFromLeague(leagueId) {
   });
 }
 
+export async function getDeletedMatchesFromLeague(leagueId: number) {
+  const rows = await db.manyOrNone(
+    `SELECT * FROM matches WHERE league_id = $1 AND is_deleted`,
+    leagueId
+  );
+  return rows.map((row) => matchRowToObj(row));
+}
+
 // TODO: The temporary league should be deleted but for "real" leagues
 // `is_deleted` should be set to true. For now there is a block in the endpoint
 // handler.

--- a/api/src/db/entities.ts
+++ b/api/src/db/entities.ts
@@ -9,3 +9,18 @@ export interface UserEntity {
   discordId?: string;
   discordUsername?: string;
 }
+
+export interface MatchEntity {
+  id: number;
+  isDeleted: boolean;
+  date?: string;
+  score?: string;
+  winningTeamId: number;
+  leagueId?: number;
+  season?: number;
+  dotaMatchId?: string; // NOTE: Or int? (VARCHAR)
+  diedFirstBlood?: number;
+  claimedFirstBlood?: number;
+  firstBloodMock?: number;
+  firstBloodPraise?: number;
+}

--- a/api/src/match.ts
+++ b/api/src/match.ts
@@ -1,10 +1,23 @@
-import { getMatch, setPlayedDateTime, setPlayedHeroesInMatch } from "./db";
+import { MatchEntity } from "./db/entities";
+import {
+  getMatch,
+  setPlayedDateTime,
+  setPlayedHeroesInMatch,
+  getDeletedMatchesFromLeague,
+} from "./db";
 import {
   timePlayed,
   heroesPlayed,
   OpenDotaMatch,
   getMatch as getOpenDotaMatch,
 } from "./external/opendota";
+
+export async function getDeletedMatches(
+  leagueId: number
+): Promise<MatchEntity[]> {
+  const matches = getDeletedMatchesFromLeague(leagueId);
+  return matches;
+}
 
 export async function fetchAllOpenDotaInfo(
   matchId: number,

--- a/api/src/routes/leagueRoutes.js
+++ b/api/src/routes/leagueRoutes.js
@@ -3,6 +3,7 @@ import Joi from "@hapi/joi";
 
 import * as db from "../db.ts";
 import { createBalancedTeams } from "../elo.ts";
+import { getDeletedMatches } from "../match.ts";
 
 const router = express.Router();
 
@@ -84,6 +85,23 @@ router.post("/:leagueId/create-teams", async (req, res, next) => {
   } catch (err) {
     console.log(err);
     res.status(500).send();
+  }
+});
+
+router.get("/:leagueId/deleted-matches", async (req, res, next) => {
+  try {
+    const leagueId = parseInt(req.params.leagueId);
+    if (isNaN(leagueId)) {
+      res.status(400);
+      return next(
+        `Incorrect league in endpoint. '${req.params.leagueId}' must be a leagueId, i.e. a numeric value.`
+      );
+    }
+
+    const matches = await getDeletedMatches(leagueId);
+    res.status(501).json({ matches });
+  } catch (err) {
+    return next(err);
   }
 });
 


### PR DESCRIPTION
This PR closes #30. The endpoint is mounted at `/league/:leagueId/deleted-matches`.
